### PR TITLE
kernel/livecd-amd64.config: Disable DRM

### DIFF
--- a/kernel/livecd-amd64.config
+++ b/kernel/livecd-amd64.config
@@ -1,0 +1,21 @@
+# Kernel config for AMD64 Livecds
+
+#Disable DRM support from being built on livecds to save space and load errors.
+DRM=n
+DRM_RADEON=n
+DRM_AMDGPU=n
+DRM_NOUVEAU=n
+DRM_I915=n
+DRM_XE=n
+DRM_VGEM=n
+DRM_VKMS=n
+DRM_VMWGFX=n
+DRM_GMA500=n
+DRM_MGAG200=n
+DRM_AST=n
+DRM_QXL=n
+DRM_VIRTIO_GPU=n
+DRM_BOCHS=n
+DRM_CIRRUS_QEMU=n
+DRM_GM12U320=n
+DRM_PANEL_MIPI_DBI=n


### PR DESCRIPTION
Disable DRM from being built to save on space and boot time errors on Dist Kernel livecds